### PR TITLE
#500

### DIFF
--- a/process/kg2pre_to_kg2c_nodes.py
+++ b/process/kg2pre_to_kg2c_nodes.py
@@ -106,7 +106,7 @@ def process_nodes(conn, nodes_input_file, nodes_output_file):
 
                 # If this node curie matches the preferred curie and the node didn't already have a description, save the KG2pre description
                 if DESCRIPTION_KEY not in kg2c_nodes[preferred_node_curie] and _is_str_none_or_empty(preferred_node_description):
-                    if preferred_node_curie == node_curie and not _is_str_none_or_empty(preferred_node_description):
+                    if preferred_node_curie == node_curie and not _is_str_none_or_empty(node_description):
                         preferred_node_dict[DESCRIPTION_KEY] = node_description
 
                 continue # Then move to next loop, since we already have the rest of the data


### PR DESCRIPTION
Frankie, I think issue #500 is a bug in `kg2pre_to_kg2c_nodes.py`. Please review this one-line change and check if you agree. If not, you cancel the PR and we can discuss the appropriate bugfix. I have not had a chance to test it; it would be great if you could test it. The test is easy. After regenerating a new KG2c nodes file using the revised script, the node with ID `NCBIGene:2554` should have this description field:

> "description": "Alpha subunit of the heteropentameric ligand-gated chloride channel gated by Gamma-aminobutyric acid (GABA), a major inhibitory neurotransmitter in the brainGABA-gated chloride channels, also named GABA(A) receptors (GABAAR), consist of five subunits arranged around a central pore and contain GABA active binding site(s) located at the alpha and beta subunit interface(s)When activated by GABA, GABAARs selectively allow the flow of chloride anions across the cell membrane down their electrochemical gradientAlpha-1/GABRA1-containing GABAARs are largely synaptic (By similarity). Chloride influx into the postsynaptic neuron following GABAAR opening decreases the neuron ability to generate a new action potential, thereby reducing nerve transmission (By similarity). GABAARs containing alpha-1 and beta-2 or -3 subunits exhibit synaptogenic activity; the gamma-2 subunit being necessary but not sufficient to induce rapid synaptic contacts formationGABAARs function also as histamine receptor where histamine binds at the interface of two neighboring beta subunits and potentiates GABA response (By similarity). GABAARs containing alpha, beta and epsilon subunits also permit spontaneous chloride channel activity while preserving the structural information required for GABA-gated openings (By similarity). Alpha-1-mediated plasticity in the orbitofrontal cortex regulates context-dependent action selection (By similarity). Together with rho subunits, may also control neuronal and glial GABAergic transmission in the cerebellum (By similarity). Belongs to the ligand-gated ion channel (TC 1.A.9) family. Gamma-aminobutyric acid receptor (TC 1.A.9.5) subfamily. GABRA1 sub-subfamily.",

(yes there is also a separate bug that makes for a lack of punctuation in the description field, and we should file a separate bug report on that; that is almost surely a bug in uniprotkb_dat_to_kg_jsonl.py).